### PR TITLE
Fix cgroup "max" value

### DIFF
--- a/kubemem.c
+++ b/kubemem.c
@@ -10,7 +10,7 @@ unsigned long parse_byte_file(char *path) {
 
   unsigned long value;
   int read_result = fscanf(file, "%lu", &value);
-  if(read_result != 0 && read_result != 1) {
+  if(read_result != 1) {
     exit(ERR_CGROUP_READ_FAILED);
   }
 

--- a/kubemem.h
+++ b/kubemem.h
@@ -15,8 +15,8 @@
 #define FAILURE_FLAG "--failure"
 #define LOGFILE_FLAG "--logfile"
 
-#define CGROUP_BYTES_USED "/sys/fs/cgroup/memory/memory.usage_in_bytes"
-#define CGROUP_BYTES_LIMIT "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+#define CGROUP_BYTES_USED "/sys/fs/cgroup/memory.current"
+#define CGROUP_BYTES_LIMIT "/sys/fs/cgroup/memory.max"
 
 struct kubemem_arguments {
   double warning_ratio;


### PR DESCRIPTION
/sys/fs/cgroup/memory.max may contain a string "max" as a value. Fail early if this happens.